### PR TITLE
Add roadmap documentation for SDK v2 port phases

### DIFF
--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -1,0 +1,33 @@
+# Spriter SDK v2 Port Roadmap
+
+This document captures the high-level phases required to port the Spriter plugin to Construct's Addon SDK v2 and provides entry points to more detailed checklists for each phase. Use it alongside `AGENTS.md` to understand the current focus and what remains.
+
+## How to use this roadmap
+
+1. Review the phase list below to see the overall progression toward the MVP and beyond. Each phase links to its own checklist.
+2. Open the corresponding phase file when you begin work to see detailed tasks, add notes, or record blockers.
+3. Update the checkboxes in both this overview and the phase files as tasks are completed so newcomers can instantly see progress.
+4. Record any external follow-ups (e.g., SDK gaps) in `requests for ashley.txt` as described in `AGENTS.md`.
+
+## Phase overview
+
+- [ ] [Phase 1 — Define the MVP contract](phases/phase-01-define-mvp-contract.md)
+- [ ] [Phase 2 — Recreate the SDK v2 runtime skeleton](phases/phase-02-runtime-skeleton.md)
+- [ ] [Phase 3 — Implement ticking and playback control](phases/phase-03-ticking-and-playback.md)
+- [ ] [Phase 4 — Render to the screen](phases/phase-04-rendering.md)
+- [ ] [Phase 5 — Harden the MVP](phases/phase-05-mvp-hardening.md)
+- [ ] [Phase 6 — Parity and polish](phases/phase-06-parity-and-polish.md)
+
+Only mark a phase complete after all checkboxes in its dedicated file are checked.
+
+## Creating additional sub-phases or documents
+
+- When a phase becomes large, create sub-phase files under `docs/phases/` using a descriptive suffix, e.g., `phase-03a-timescale-support.md`. Link them from the parent phase file under a "Sub-phases" heading.
+- Keep naming consistent and ordered lexicographically so they remain easy to scan (`phase-03a`, `phase-03b`, etc.).
+- If a sub-phase emerges that multiple agents will touch, add a short summary of its scope and owner at the top of the new file.
+
+## Keeping the roadmap healthy
+
+- Each phase file contains guidance on when to expand with additional checklists; follow those prompts to keep work manageable.
+- Consider adding dates, owners, or notes next to checkboxes if coordination across agents is needed.
+- If priorities shift (e.g., we choose to skip ahead to rendering), update the order or status annotations in this file so the plan stays truthful.

--- a/docs/phases/phase-01-define-mvp-contract.md
+++ b/docs/phases/phase-01-define-mvp-contract.md
@@ -1,0 +1,16 @@
+# Phase 1 — Define the MVP contract
+
+## Goal
+Clarify the minimum behaviour required to "load and display a Spriter animation" using SDK v2, establishing the reference scope for the MVP.
+
+## Checklist
+- [ ] Review the legacy runtime under `scml/c3runtime` to list the subsystems needed for loading, ticking, and drawing a single animation.
+- [ ] Document the agreed-upon MVP behaviours and required SDK v2 lifecycle hooks in a shared design note (e.g., markdown in `docs/`).
+- [ ] Record open questions or missing SDK features in `requests for ashley.txt` with references.
+
+## Using this file
+- Update the checklist as you confirm each item. Add short notes or links next to checkboxes if helpful for later phases.
+- If the investigation grows, create sub-phase files under `docs/phases/` with a `phase-01x-*.md` naming pattern and link them below.
+
+## Sub-phases
+_None yet. Add bullet links here when you split out deeper work._

--- a/docs/phases/phase-02-runtime-skeleton.md
+++ b/docs/phases/phase-02-runtime-skeleton.md
@@ -1,0 +1,17 @@
+# Phase 2 — Recreate the SDK v2 runtime skeleton
+
+## Goal
+Port the foundational runtime structure to SDK v2 so Spriter instances can be created, hold state, and clean up correctly.
+
+## Checklist
+- [ ] Port initialization/storage fields from the legacy instance into the SDK v2 constructor and `_onCreate` implementation.
+- [ ] Implement asset loading and parsing helpers to ensure Spriter data is available during `_onCreate`.
+- [ ] Add `_onDestroy` and `_release` cleanup logic for textures, timelines, and event listeners created during initialization.
+
+## Using this file
+- Mark checkboxes once code lands in `scml2/` with tests or validation notes.
+- Capture dependencies (e.g., required Construct runtime APIs) in line-comments or in `requests for ashley.txt`.
+- If this phase becomes unwieldy, spin off sub-phases like `phase-02a-asset-loading.md` and link them below.
+
+## Sub-phases
+_None yet. Add bullet links here when you split out deeper work._

--- a/docs/phases/phase-03-ticking-and-playback.md
+++ b/docs/phases/phase-03-ticking-and-playback.md
@@ -1,0 +1,16 @@
+# Phase 3 — Implement ticking and playback control
+
+## Goal
+Ensure the SDK v2 runtime can advance Spriter animations each tick and expose minimal controls to choose entities and animations.
+
+## Checklist
+- [ ] Port timekeeping helpers (e.g., `getNowTime`) and ensure they respect Construct's timescale options when advancing animations.
+- [ ] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`.
+- [ ] Expose at least one action (e.g., `Set Animation`) through `C3.Plugins.Spriter.Acts` to drive playback from Construct events.
+
+## Using this file
+- Record timing edge cases or Construct integration notes inline so later contributors understand constraints.
+- Break out complex subsystems—such as blending or event firing—into `phase-03x-*.md` sub-phases when needed and link them below.
+
+## Sub-phases
+_None yet. Add bullet links here when you split out deeper work._

--- a/docs/phases/phase-04-rendering.md
+++ b/docs/phases/phase-04-rendering.md
@@ -1,0 +1,17 @@
+# Phase 4 — Render to the screen
+
+## Goal
+Display Spriter animations through the Construct renderer so the MVP requirement of "load and play an animation" is visibly met.
+
+## Checklist
+- [ ] Translate the legacy `Draw` routine to SDK v2, adapting renderer calls to the new APIs.
+- [ ] Handle flipping, blending, texture atlas lookups, and layer ordering so each timeline element renders correctly.
+- [ ] Build or update a Construct test project to confirm animations appear and respond to playback actions.
+
+## Using this file
+- Capture renderer-specific quirks (e.g., batching limits, WebGL requirements) in notes next to the relevant checklist item.
+- If multiple rendering paths are needed (canvas vs. WebGL, character maps, etc.), create sub-files such as `phase-04a-webgl.md` and link them below.
+- Remember to attach screenshots or GIFs to PRs demonstrating the animation once this phase is complete.
+
+## Sub-phases
+_None yet. Add bullet links here when you split out deeper work._

--- a/docs/phases/phase-05-mvp-hardening.md
+++ b/docs/phases/phase-05-mvp-hardening.md
@@ -1,0 +1,17 @@
+# Phase 5 — Harden the MVP
+
+## Goal
+Stabilize the MVP by supporting persistence, debugging, and essential scripting hooks so teams can rely on the addon in real projects.
+
+## Checklist
+- [ ] Implement `_saveToJson` and `_loadFromJson` for critical runtime state (current entity, animation, playback time, etc.).
+- [ ] Populate `_getDebuggerProperties` with useful inspection data (e.g., selected animation, paused/playing state).
+- [ ] Port high-value conditions and expressions such as "Current animation" and playback time queries.
+
+## Using this file
+- When adding serialization or debugger fields, document any SDK constraints or design decisions inline.
+- If the scope branches significantly (e.g., saving/loading vs. debugger), create sub-phase files like `phase-05a-serialization.md` and link them below.
+- Capture regression tests or Construct project links that validate the hardening work.
+
+## Sub-phases
+_None yet. Add bullet links here when you split out deeper work._

--- a/docs/phases/phase-06-parity-and-polish.md
+++ b/docs/phases/phase-06-parity-and-polish.md
@@ -1,0 +1,17 @@
+# Phase 6 — Parity and polish
+
+## Goal
+Achieve feature parity with the legacy addon, optimize performance, and finalize documentation and samples.
+
+## Checklist
+- [ ] Port the remaining actions, conditions, and expressions from the README roadmap, validating against legacy behaviour.
+- [ ] Optimize rendering and ticking paths (batching, caching, Construct feature compatibility).
+- [ ] Refresh README/docs with SDK v2 instructions and updated example projects.
+
+## Using this file
+- Keep a running list of completed API groups or optimization wins beneath the relevant checkboxes.
+- Split major efforts (e.g., documentation overhaul vs. performance tuning) into sub-phase files such as `phase-06a-performance.md` and link them below.
+- Note any external dependencies or release criteria (e.g., Construct store submission requirements).
+
+## Sub-phases
+_None yet. Add bullet links here when you split out deeper work._


### PR DESCRIPTION
## Summary
- add a top-level roadmap document that links the major phases of the SDK v2 port
- create individual phase checklists with guidance on tracking progress and adding sub-phases

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f9e6a4b89483229c1b26bb45c821d0