### PR TITLE
Document legacy Spriter runtime survey for phase 1

### DIFF
--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -11,7 +11,7 @@ This document captures the high-level phases required to port the Spriter plugin
 
 ## Phase overview
 
-- [ ] [Phase 1 — Define the MVP contract](phases/phase-01-define-mvp-contract.md)
+- [x] [Phase 1 — Define the MVP contract](phases/phase-01-define-mvp-contract.md)
 - [ ] [Phase 2 — Recreate the SDK v2 runtime skeleton](phases/phase-02-runtime-skeleton.md)
 - [ ] [Phase 3 — Implement ticking and playback control](phases/phase-03-ticking-and-playback.md)
 - [ ] [Phase 4 — Render to the screen](phases/phase-04-rendering.md)

--- a/docs/phases/phase-01-define-mvp-contract.md
+++ b/docs/phases/phase-01-define-mvp-contract.md
@@ -4,13 +4,13 @@
 Clarify the minimum behaviour required to "load and display a Spriter animation" using SDK v2, establishing the reference scope for the MVP.
 
 ## Checklist
-- [ ] Review the legacy runtime under `scml/c3runtime` to list the subsystems needed for loading, ticking, and drawing a single animation.
-- [ ] Document the agreed-upon MVP behaviours and required SDK v2 lifecycle hooks in a shared design note (e.g., markdown in `docs/`).
-- [ ] Record open questions or missing SDK features in `requests for ashley.txt` with references.
+- [x] Review the legacy runtime under `scml/c3runtime` to list the subsystems needed for loading, ticking, and drawing a single animation. See the findings captured in [`phase-01a-legacy-runtime-survey.md`](phase-01a-legacy-runtime-survey.md).
+- [x] Document the agreed-upon MVP behaviours and required SDK v2 lifecycle hooks in a shared design note (e.g., markdown in `docs/`). The same survey file lists the minimum behaviours to port first.
+- [x] Record open questions or missing SDK features in `requests for ashley.txt` with references. None were identified during this pass, so no entry was required.
 
 ## Using this file
 - Update the checklist as you confirm each item. Add short notes or links next to checkboxes if helpful for later phases.
 - If the investigation grows, create sub-phase files under `docs/phases/` with a `phase-01x-*.md` naming pattern and link them below.
 
 ## Sub-phases
-_None yet. Add bullet links here when you split out deeper work._
+- [Phase 01a — Legacy runtime survey](phase-01a-legacy-runtime-survey.md)

--- a/docs/phases/phase-01a-legacy-runtime-survey.md
+++ b/docs/phases/phase-01a-legacy-runtime-survey.md
@@ -1,0 +1,48 @@
+# Phase 01a — Legacy runtime survey
+
+## Purpose
+This note captures the minimum systems from the legacy SDK v1 runtime under
+`scml/c3runtime` that are required to load and display a Spriter animation.
+It should be used alongside `phase-01-define-mvp-contract.md` when deciding
+what to port to SDK v2.
+
+## Legacy subsystems needed for the MVP
+- **Instance state and ticking** – `onCreate` initialises the per-instance
+  caches, playback flags, and registers both tick passes so animation logic
+  runs even before explicit actions are invoked.【F:scml/c3runtime/instance.js†L633-L737】【F:scml/c3runtime/instance.js†L1999-L2007】
+- **Shared asset caching** – the plugin type preloads sprite sheet frames and
+  tracks the parsed SCON data so that multiple Spriter instances reuse the same
+  definitions.【F:scml/c3runtime/type.js†L18-L38】
+- **SCON loading & hydration** – instances asynchronously request the `.scon`
+  project file, then `doRequest` populates entities, triggers the
+  `readyForSetup` condition, and notifies any waiting instances so they can
+  share the parsed data.【F:scml/c3runtime/instance.js†L739-L755】【F:scml/c3runtime/instance.js†L3805-L3834】
+- **Data model construction** – `setEntitiesToOtherEntities` and the helper
+  constructors at the end of the file materialise entities, animations,
+  timelines, and object metadata from the raw SCON JSON.【F:scml/c3runtime/instance.js†L331-L406】【F:scml/c3runtime/instance.js†L5371-L5556】
+- **Per-frame playback** – `Tick` clears overrides each frame, while `Tick2`
+  ensures data is loaded, advances animation time, pauses when outside the
+  viewport buffer, and drives `ProcessNonSoundAnimation` / `animateCharacter`
+  to update sprite timelines.【F:scml/c3runtime/instance.js†L1999-L2211】【F:scml/c3runtime/instance.js†L2244-L2319】
+- **Rendering** – `Draw` iterates the current mainline key, resolves sprite
+  frames, applies mirroring and pivot math, and submits textured quads to the
+  renderer.【F:scml/c3runtime/instance.js†L79-L307】
+
+## Minimum behaviours to port to SDK v2
+- Implement `_onCreate` to capture initial properties, bootstrap ticking, and
+  kick off SCON loading/caching so the instance mirrors the legacy setup
+  workflow.【F:scml2/c3runtime/instance.js†L5-L33】【F:scml/c3runtime/instance.js†L633-L755】
+- Implement `_tick` (and any auxiliary update helpers) to merge the legacy
+  `Tick`/`Tick2` responsibilities: reset overrides, ensure data availability,
+  advance animation time, and drive sprite/object updates before rendering.
+  【F:scml2/c3runtime/instance.js†L35-L38】【F:scml/c3runtime/instance.js†L1999-L2211】
+- Implement `_draw` to reuse the prepared timeline state and emit the correct
+  textured quads so single-entity animations display in the layout, matching
+  the SDK v1 behaviour.【F:scml2/c3runtime/instance.js†L30-L33】【F:scml/c3runtime/instance.js†L79-L307】
+- Flesh out `_release`, `_onDestroy`, and save/load helpers to clean up shared
+  caches and persist any per-instance state required for savegames, mirroring
+  the structure provided by the legacy runtime stubs.【F:scml2/c3runtime/instance.js†L15-L49】【F:scml/c3runtime/instance.js†L318-L328】
+
+## Open questions
+No SDK gaps or blocking questions were identified during this survey, so no
+entry is required in `requests for ashley.txt` at this time.


### PR DESCRIPTION
## Summary
- capture the critical SDK v1 subsystems needed to load and display a Spriter animation
- record the minimum SDK v2 lifecycle work for the MVP and link it from the phase 1 checklist
- mark the roadmap phase as complete now that the contract is documented

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f9ef2d9bdc8322b7db7cb5458aff31