### PR TITLE
Clarify roadmap navigation and pacing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - This repository is in the process of porting the legacy Spriter plugin found under `scml/` to Construct's Addon SDK v2.
 - Reference the official Construct guide on porting: <https://www.construct.net/en/make-games/manuals/addon-sdk/guide/porting-addon-sdk-v2>.
 - While porting, take the opportunity to dramatically clean up the codebase—the legacy implementation is known to be messy, so prefer clear structure, modern patterns, and thorough documentation.
+- When you need direction on which area of the port to tackle next, start in `docs/`. The root roadmap (`docs/MVP_PLAN.md`) links to detailed phase checklists under `docs/phases/` that outline the current priorities.
 
 ## Research expectations
 - Use the linked Construct manual page as the primary starting point.

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -6,8 +6,9 @@ This document captures the high-level phases required to port the Spriter plugin
 
 1. Review the phase list below to see the overall progression toward the MVP and beyond. Each phase links to its own checklist.
 2. Open the corresponding phase file when you begin work to see detailed tasks, add notes, or record blockers.
-3. Update the checkboxes in both this overview and the phase files as tasks are completed so newcomers can instantly see progress.
-4. Record any external follow-ups (e.g., SDK gaps) in `requests for ashley.txt` as described in `AGENTS.md`.
+3. Use your judgement to select a manageable slice of work at a time; if the next set of tasks looks large enough to risk context loss or tangled bugs, pause and ask your human collaborator to review progress before continuing. Avoid over-splitting trivial or tightly-coupled changes.
+4. Update the checkboxes in both this overview and the phase files as tasks are completed so newcomers can instantly see progress.
+5. Record any external follow-ups (e.g., SDK gaps) in `requests for ashley.txt` as described in `AGENTS.md`.
 
 ## Phase overview
 


### PR DESCRIPTION
## Summary
- highlight the roadmap documents in `docs/` from `AGENTS.md` so contributors know where to find next steps
- add pacing guidance to the roadmap instructions about choosing a manageable slice of work and syncing with the human reviewer when needed

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f9fa71a3cc8322a74acc4a987f729e