### PR TITLE
Implement basic Spriter animation ticking

### DIFF
--- a/docs/phases/phase-03-ticking-and-playback.md
+++ b/docs/phases/phase-03-ticking-and-playback.md
@@ -4,9 +4,9 @@
 Ensure the SDK v2 runtime can advance Spriter animations each tick and expose minimal controls to choose entities and animations.
 
 ## Checklist
-- [ ] Port timekeeping helpers (e.g., `getNowTime`) and ensure they respect Construct's timescale options when advancing animations.
-- [ ] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`.
-- [ ] Expose at least one action (e.g., `Set Animation`) through `C3.Plugins.Spriter.Acts` to drive playback from Construct events.
+- [x] Port timekeeping helpers (e.g., `getNowTime`) and ensure they respect Construct's timescale options when advancing animations.
+- [ ] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`. _(Entity selection and animation timing added; keyframe interpolation remains to be ported.)_
+- [x] Expose at least one action (e.g., `Set Animation`) through `C3.Plugins.Spriter.Acts` to drive playback from Construct events.
 
 ## Using this file
 - Record timing edge cases or Construct integration notes inline so later contributors understand constraints.

--- a/scml2/c3runtime/actions.js
+++ b/scml2/c3runtime/actions.js
@@ -2,5 +2,38 @@ const C3 = globalThis.C3;
 
 C3.Plugins.Spriter.Acts =
 {
-        // TODO: port actions from the legacy runtime.
+        setAnimation(animationName, startFrom = 0, blendDuration = 0)
+        {
+                const targetName = (typeof animationName === "string") ? animationName : toStringOrEmpty(animationName);
+                const numericStartFrom = Number(startFrom);
+                const resolvedStartFrom = Number.isFinite(numericStartFrom) ? numericStartFrom : 0;
+                const numericBlendDuration = Number(blendDuration);
+                const resolvedBlendDuration = Number.isFinite(numericBlendDuration) ? numericBlendDuration : 0;
+
+                if (typeof this._setAnimation === "function")
+                {
+                        this._setAnimation(targetName, resolvedStartFrom, resolvedBlendDuration);
+                        return;
+                }
+
+                if (typeof console !== "undefined" && console && typeof console.warn === "function")
+                {
+                        console.warn("[Spriter] Attempted to set an animation before the runtime initialised the playback system." );
+                }
+        }
 };
+
+function toStringOrEmpty(value)
+{
+        if (typeof value === "string")
+        {
+                return value;
+        }
+
+        if (value == null)
+        {
+                return "";
+        }
+
+        return String(value);
+}

--- a/scml2/c3runtime/instance.js
+++ b/scml2/c3runtime/instance.js
@@ -100,8 +100,13 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this.lastData = "";
                 this.progress = 0;
 
-                this.entity = 0;
+                this.entityIndex = -1;
+                this.entity = null;
                 this.entities = [];
+
+                this.currentAnimation = null;
+                this.currentAnimationIndex = -1;
+                this.currentAnimationName = "";
 
                 this.currentSpriterTime = 0;
                 this.currentAdjustedTime = 0;
@@ -135,6 +140,7 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this._registeredTimelines = new Set();
                 this._eventListenerDisposables = new Set();
                 this._isReleased = false;
+                this._hasShownBlendWarning = false;
         }
 
         _release()
@@ -182,8 +188,8 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this.folders = [];
                 this.tagDefs = [];
 
-                this.currentAnimation = "";
-                this.secondAnimation = "";
+                this.currentAnimation = null;
+                this.secondAnimation = null;
                 this.animBlend = 0.0;
                 this.blendStartTime = 0.0;
                 this.blendEndTime = 0.0;
@@ -382,7 +388,13 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
 
                         if (Array.isArray(projectData.entity))
                         {
-                                this.entities = projectData.entity;
+                                this.entities = projectData.entity
+                                        .map((entity) => this._normaliseEntityDefinition(entity))
+                                        .filter((entity) => entity !== null);
+                        }
+                        else
+                        {
+                                this.entities = [];
                         }
 
                         if (Array.isArray(projectData.tag_list))
@@ -405,6 +417,12 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                                         .filter((tagName) => typeof tagName === "string");
                         }
                 }
+                else
+                {
+                        this.entities = [];
+                }
+
+                this._applyPendingPlaybackPreferences();
         }
 
         _handleProjectDataLoadError(projectFileName, error)
@@ -426,6 +444,12 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this._rawSpriterProject = null;
                 this._isProjectDataReady = false;
                 this._projectDataLoadError = loadError;
+                this.entities = [];
+                this.entity = null;
+                this.entityIndex = -1;
+                this.currentAnimation = null;
+                this.currentAnimationIndex = -1;
+                this.currentAnimationName = "";
 
                 if (typeof console !== "undefined" && console)
                 {
@@ -660,6 +684,12 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this.soundLineToTrigger = {};
                 this.eventLineToTrigger = {};
                 this.lastFoundObject = "";
+
+                this.currentAnimation = null;
+                this.currentAnimationIndex = -1;
+                this.currentAnimationName = "";
+                this.currentSpriterTime = 0;
+                this.currentAdjustedTime = 0;
         }
 
         _clearProjectDataReferences()
@@ -672,7 +702,15 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
 
                 this.folders = [];
                 this.entities = [];
+                this.entity = null;
+                this.entityIndex = -1;
+                this.currentAnimation = null;
+                this.currentAnimationIndex = -1;
+                this.currentAnimationName = "";
+                this.currentSpriterTime = 0;
+                this.currentAdjustedTime = 0;
                 this.tagDefs = [];
+                this._hasShownBlendWarning = false;
         }
 
         _logCleanupWarning(resourceType, error)
@@ -681,6 +719,559 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 {
                         console.warn(`[Spriter] Failed to clean up ${resourceType}:`, error);
                 }
+        }
+
+        _normaliseEntityDefinition(entityDefinition)
+        {
+                if (!entityDefinition || typeof entityDefinition !== "object")
+                {
+                        return null;
+                }
+
+                const normalised = { ...entityDefinition };
+                const animations = [];
+
+                if (Array.isArray(entityDefinition.animations))
+                {
+                        for (const animation of entityDefinition.animations)
+                        {
+                                if (animation && typeof animation === "object")
+                                {
+                                        animations.push(animation);
+                                }
+                        }
+                }
+                else if (Array.isArray(entityDefinition.animation))
+                {
+                        for (const animation of entityDefinition.animation)
+                        {
+                                if (animation && typeof animation === "object")
+                                {
+                                        animations.push(animation);
+                                }
+                        }
+                }
+
+                normalised.animation = animations;
+                normalised.animations = animations;
+                return normalised;
+        }
+
+        _applyPendingPlaybackPreferences()
+        {
+                if (!Array.isArray(this.entities) || this.entities.length === 0)
+                {
+                        this._setActiveEntity(null, -1);
+                        return;
+                }
+
+                const entityPreference = this.startingEntName || this.properties[PROPERTY_INDEX.STARTING_ENTITY];
+                if (!this._setActiveEntityByName(entityPreference))
+                {
+                        const numericPreference = Number(entityPreference);
+                        if (!Number.isInteger(numericPreference) || !this._setActiveEntityByIndex(numericPreference))
+                        {
+                                this._setActiveEntityByIndex(0);
+                        }
+                }
+
+                const animationPreference = this.startingAnimName || this.properties[PROPERTY_INDEX.STARTING_ANIMATION];
+                if (!this._setAnimation(animationPreference, 0, 0))
+                {
+                        const fallbackAnimation = this._getFallbackAnimationName();
+                        if (fallbackAnimation)
+                        {
+                                this._setAnimation(fallbackAnimation, 0, 0);
+                        }
+                }
+        }
+
+        _getRuntime()
+        {
+                return (typeof this.GetRuntime === "function") ? this.GetRuntime() : null;
+        }
+
+        _getNowTime()
+        {
+                const runtime = this._getRuntime();
+                if (runtime && typeof runtime.GetWallTime === "function")
+                {
+                        return runtime.GetWallTime();
+                }
+
+                if (typeof performance !== "undefined" && performance && typeof performance.now === "function")
+                {
+                        return performance.now() / 1000;
+                }
+
+                return Date.now() / 1000;
+        }
+
+        _getRuntimeTimeScale()
+        {
+                if (this.ignoreGlobalTimeScale)
+                {
+                        return 1;
+                }
+
+                if (typeof this.GetTimeScale === "function")
+                {
+                        const instanceTimeScale = this.GetTimeScale();
+                        if (Number.isFinite(instanceTimeScale) && instanceTimeScale >= 0 && instanceTimeScale !== -1)
+                        {
+                                return instanceTimeScale;
+                        }
+                }
+
+                const runtime = this._getRuntime();
+                if (runtime && typeof runtime.GetTimeScale === "function")
+                {
+                        const timeScale = runtime.GetTimeScale();
+                        if (Number.isFinite(timeScale))
+                        {
+                                return timeScale;
+                        }
+                }
+
+                return 1;
+        }
+
+        _getAnimationsForEntity(entity)
+        {
+                if (!entity || typeof entity !== "object")
+                {
+                        return [];
+                }
+
+                if (Array.isArray(entity.animations))
+                {
+                        return entity.animations;
+                }
+
+                if (Array.isArray(entity.animation))
+                {
+                        return entity.animation;
+                }
+
+                return [];
+        }
+
+        _findEntity(identifier)
+        {
+                const entities = Array.isArray(this.entities) ? this.entities : [];
+                if (!entities.length)
+                {
+                        return { entity: null, index: -1 };
+                }
+
+                if (typeof identifier === "number" && Number.isInteger(identifier))
+                {
+                        for (let i = 0; i < entities.length; i++)
+                        {
+                                const candidate = entities[i];
+                                if (candidate && typeof candidate.id === "number" && candidate.id === identifier)
+                                {
+                                        return { entity: candidate, index: i };
+                                }
+                        }
+
+                        if (identifier >= 0 && identifier < entities.length)
+                        {
+                                return { entity: entities[identifier], index: identifier };
+                        }
+                }
+
+                if (typeof identifier === "string")
+                {
+                        const trimmed = identifier.trim();
+                        if (trimmed)
+                        {
+                                const numeric = Number(trimmed);
+                                if (Number.isInteger(numeric))
+                                {
+                                        for (let i = 0; i < entities.length; i++)
+                                        {
+                                                const candidate = entities[i];
+                                                if (candidate && typeof candidate.id === "number" && candidate.id === numeric)
+                                                {
+                                                        return { entity: candidate, index: i };
+                                                }
+                                        }
+
+                                        if (numeric >= 0 && numeric < entities.length)
+                                        {
+                                                return { entity: entities[numeric], index: numeric };
+                                        }
+                                }
+
+                                const lower = trimmed.toLowerCase();
+                                for (let i = 0; i < entities.length; i++)
+                                {
+                                        const candidate = entities[i];
+                                        if (candidate && typeof candidate.name === "string" && candidate.name.trim().toLowerCase() === lower)
+                                        {
+                                                return { entity: candidate, index: i };
+                                        }
+                                }
+                        }
+                }
+
+                return { entity: null, index: -1 };
+        }
+
+        _setActiveEntityByName(identifier)
+        {
+                if (identifier == null || identifier === "")
+                {
+                        return false;
+                }
+
+                const { entity, index } = this._findEntity(identifier);
+                if (!entity)
+                {
+                        return false;
+                }
+
+                this._setActiveEntity(entity, index);
+                return true;
+        }
+
+        _setActiveEntityByIndex(index)
+        {
+                const entities = Array.isArray(this.entities) ? this.entities : [];
+                if (!Number.isInteger(index) || index < 0 || index >= entities.length)
+                {
+                        return false;
+                }
+
+                this._setActiveEntity(entities[index], index);
+                return true;
+        }
+
+        _setActiveEntity(entity, index)
+        {
+                if (!entity)
+                {
+                        this.entity = null;
+                        this.entityIndex = -1;
+                        this.currentAnimation = null;
+                        this.currentAnimationIndex = -1;
+                        this.currentAnimationName = "";
+                        this.currentSpriterTime = 0;
+                        this.currentAdjustedTime = 0;
+                        return false;
+                }
+
+                this.entity = entity;
+                if (Array.isArray(this.entities))
+                {
+                        if (Number.isInteger(index) && index >= 0 && index < this.entities.length)
+                        {
+                                this.entityIndex = index;
+                        }
+                        else
+                        {
+                                this.entityIndex = this.entities.indexOf(entity);
+                        }
+                }
+                else
+                {
+                        this.entityIndex = -1;
+                }
+
+                this.currentAnimation = null;
+                this.currentAnimationIndex = -1;
+                this.currentAnimationName = "";
+                this.currentSpriterTime = 0;
+                this.currentAdjustedTime = 0;
+
+                if (entity && typeof entity.name === "string" && entity.name)
+                {
+                        this.startingEntName = entity.name;
+                }
+
+                return true;
+        }
+
+        _getFallbackAnimationName()
+        {
+                const animations = this._getAnimationsForEntity(this.entity);
+                if (!animations.length)
+                {
+                        return "";
+                }
+
+                const firstAnimation = animations[0];
+                if (firstAnimation && typeof firstAnimation.name === "string")
+                {
+                        return firstAnimation.name;
+                }
+
+                return "";
+        }
+
+        _findAnimation(identifier, allowFallback = false)
+        {
+                const entity = this.entity;
+                const animations = this._getAnimationsForEntity(entity);
+
+                if (!animations.length)
+                {
+                        return { animation: null, index: -1 };
+                }
+
+                if (identifier == null || identifier === "")
+                {
+                        return allowFallback ? { animation: animations[0], index: 0 } : { animation: null, index: -1 };
+                }
+
+                if (typeof identifier === "number" && Number.isInteger(identifier))
+                {
+                        for (let i = 0, len = animations.length; i < len; i++)
+                        {
+                                const candidate = animations[i];
+                                if (candidate && typeof candidate.id === "number" && candidate.id === identifier)
+                                {
+                                        return { animation: candidate, index: i };
+                                }
+                        }
+
+                        if (identifier >= 0 && identifier < animations.length)
+                        {
+                                return { animation: animations[identifier], index: identifier };
+                        }
+                }
+
+                if (typeof identifier === "string")
+                {
+                        const trimmed = identifier.trim();
+                        if (trimmed)
+                        {
+                                const numeric = Number(trimmed);
+                                if (Number.isInteger(numeric))
+                                {
+                                        for (let i = 0, len = animations.length; i < len; i++)
+                                        {
+                                                const candidate = animations[i];
+                                                if (candidate && typeof candidate.id === "number" && candidate.id === numeric)
+                                                {
+                                                        return { animation: candidate, index: i };
+                                                }
+                                        }
+
+                                        if (numeric >= 0 && numeric < animations.length)
+                                        {
+                                                return { animation: animations[numeric], index: numeric };
+                                        }
+                                }
+
+                                const lower = trimmed.toLowerCase();
+                                for (let i = 0, len = animations.length; i < len; i++)
+                                {
+                                        const candidate = animations[i];
+                                        if (candidate && typeof candidate.name === "string" && candidate.name.trim().toLowerCase() === lower)
+                                        {
+                                                return { animation: candidate, index: i };
+                                        }
+                                }
+                        }
+                }
+
+                return allowFallback ? { animation: animations[0], index: 0 } : { animation: null, index: -1 };
+        }
+
+        _setAnimation(animationIdentifier, startFrom = 0, blendDuration = 0)
+        {
+                const allowFallback = animationIdentifier == null || animationIdentifier === "";
+                const { animation, index } = this._findAnimation(animationIdentifier, allowFallback);
+
+                if (!animation)
+                {
+                        if (typeof animationIdentifier === "string" && animationIdentifier)
+                        {
+                                this.startingAnimName = animationIdentifier;
+                        }
+                        return false;
+                }
+
+                if (blendDuration > 0 && !this._hasShownBlendWarning && typeof console !== "undefined" && console && typeof console.warn === "function")
+                {
+                        console.warn("[Spriter] Animation blending is not yet supported in the SDK v2 runtime. Ignoring blend duration.");
+                        this._hasShownBlendWarning = true;
+                }
+
+                const previousAnimation = this.currentAnimation;
+                const previousLength = this._getAnimationLength(previousAnimation);
+                const previousRatio = previousLength > 0 ? Math.max(0, Math.min(1, this.currentSpriterTime / previousLength)) : 0;
+
+                this.currentAnimation = animation;
+                this.currentAnimationIndex = index;
+                this.currentAnimationName = (animation && typeof animation.name === "string") ? animation.name : "";
+                this.startingAnimName = this.currentAnimationName || (typeof animationIdentifier === "string" ? animationIdentifier : "");
+
+                const length = this._getAnimationLength(animation);
+                let nextTime = this.currentSpriterTime;
+
+                switch (startFrom)
+                {
+                        case this.PLAYFROMSTART:
+                                nextTime = this.speedRatio >= 0 ? 0 : length;
+                                break;
+                        case this.PLAYFROMCURRENTTIME:
+                                nextTime = Math.max(0, Math.min(length, this.currentSpriterTime));
+                                break;
+                        case this.PLAYFROMCURRENTTIMERATIO:
+                        case this.BLENDATCURRENTTIMERATIO:
+                                nextTime = Math.max(0, Math.min(length, previousRatio * length));
+                                break;
+                        case this.BLENDTOSTART:
+                                nextTime = this.speedRatio >= 0 ? 0 : length;
+                                break;
+                        default:
+                                nextTime = Math.max(0, Math.min(length, this.currentSpriterTime));
+                                break;
+                }
+
+                if (!Number.isFinite(nextTime))
+                {
+                        nextTime = 0;
+                }
+
+                this.currentSpriterTime = nextTime;
+                this.currentAdjustedTime = Math.max(0, Math.min(length, this.currentSpriterTime));
+                this.lastKnownTime = this._getNowTime();
+
+                this.playTo = -1;
+                this.changeToStartFrom = startFrom;
+                this.blendStartTime = 0;
+                this.blendEndTime = 0;
+                this.blendPoseTime = 0;
+                this.secondAnimation = null;
+                this.animBlend = 0;
+                this.changeAnimTo = null;
+                this.animPlaying = true;
+                this.force = true;
+
+                this._updateWorldBoundsFromAnimation(animation);
+                return true;
+        }
+
+        _onAnimationFinished(animation)
+        {
+                // TODO: trigger Construct events once the event system has been ported.
+        }
+
+        _updateWorldBoundsFromAnimation(animation)
+        {
+                if (!animation)
+                {
+                        return;
+                }
+
+                const worldInfo = (typeof this.GetWorldInfo === "function") ? this.GetWorldInfo() : null;
+                if (!worldInfo)
+                {
+                        return;
+                }
+
+                const left = this._coerceNumber(animation.l, 0);
+                const right = this._coerceNumber(animation.r, left + 1);
+                const top = this._coerceNumber(animation.t, 0);
+                const bottom = this._coerceNumber(animation.b, top + 1);
+
+                const widthWithoutScale = right - left;
+                const heightWithoutScale = bottom - top;
+
+                if (!(Number.isFinite(widthWithoutScale) && widthWithoutScale > 0) || !(Number.isFinite(heightWithoutScale) && heightWithoutScale > 0))
+                {
+                        return;
+                }
+
+                const scaledWidth = widthWithoutScale * this.scaleRatio;
+                const scaledHeight = heightWithoutScale * this.scaleRatio;
+
+                if (Number.isFinite(scaledWidth) && scaledWidth > 0 && typeof worldInfo.SetWidth === "function")
+                {
+                        worldInfo.SetWidth(scaledWidth);
+                }
+
+                if (Number.isFinite(scaledHeight) && scaledHeight > 0 && typeof worldInfo.SetHeight === "function")
+                {
+                        worldInfo.SetHeight(scaledHeight);
+                }
+
+                if (Number.isFinite(widthWithoutScale) && widthWithoutScale !== 0 && typeof worldInfo.SetOriginX === "function")
+                {
+                        const offsetX = this.xFlip ? -right : left;
+                        worldInfo.SetOriginX(-(offsetX) / widthWithoutScale);
+                }
+
+                if (Number.isFinite(heightWithoutScale) && heightWithoutScale !== 0 && typeof worldInfo.SetOriginY === "function")
+                {
+                        const offsetY = this.yFlip ? -bottom : top;
+                        worldInfo.SetOriginY(-(offsetY) / heightWithoutScale);
+                }
+
+                if (typeof worldInfo.SetBboxChanged === "function")
+                {
+                        worldInfo.SetBboxChanged();
+                }
+        }
+
+        _coerceNumber(value, fallback = 0)
+        {
+                const numberValue = Number(value);
+                return Number.isFinite(numberValue) ? numberValue : fallback;
+        }
+
+        _getAnimationLength(animation)
+        {
+                if (!animation || typeof animation !== "object")
+                {
+                        return 0;
+                }
+
+                const length = Number(animation.length);
+                return Number.isFinite(length) && length >= 0 ? length : 0;
+        }
+
+        _isAnimationLooping(animation)
+        {
+                if (!animation || typeof animation !== "object")
+                {
+                        return false;
+                }
+
+                const looping = animation.looping;
+                if (typeof looping === "string")
+                {
+                        return looping.toLowerCase() !== "false";
+                }
+
+                if (typeof looping === "boolean")
+                {
+                        return looping;
+                }
+
+                if (typeof looping === "number")
+                {
+                        return looping !== 0;
+                }
+
+                return true;
+        }
+
+        _getCurrentTimeRatio()
+        {
+                const animation = this.currentAnimation;
+                const length = this._getAnimationLength(animation);
+
+                if (length <= 0)
+                {
+                        return 0;
+                }
+
+                return Math.max(0, Math.min(1, this.currentSpriterTime / length));
         }
 
         _onDestroy()
@@ -714,7 +1305,97 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
 
         _tick()
         {
-                // TODO: advance animation state each frame.
+                const previousKnownTime = this.lastKnownTime;
+                const now = this._getNowTime();
+                this.lastKnownTime = now;
+
+                const animation = this.currentAnimation;
+                if (!animation)
+                {
+                        return;
+                }
+
+                const length = this._getAnimationLength(animation);
+                if (length <= 0)
+                {
+                        this.currentSpriterTime = 0;
+                        this.currentAdjustedTime = 0;
+                        return;
+                }
+
+                const previousSpriterTime = this.currentSpriterTime;
+
+                if (this.animPlaying)
+                {
+                        const deltaSecondsRaw = now - previousKnownTime;
+                        const deltaSeconds = Number.isFinite(deltaSecondsRaw) ? Math.max(0, deltaSecondsRaw) : 0;
+
+                        if (deltaSeconds !== 0)
+                        {
+                                const timeScale = this._getRuntimeTimeScale();
+                                const deltaMs = deltaSeconds * 1000 * this.speedRatio * timeScale;
+
+                                if (Number.isFinite(deltaMs) && deltaMs !== 0)
+                                {
+                                        this.currentSpriterTime += deltaMs;
+                                }
+                        }
+                }
+
+                let animationFinished = false;
+
+                if (Number.isFinite(this.playTo) && this.playTo >= 0)
+                {
+                        const playTo = this.playTo;
+                        if ((previousSpriterTime - playTo) * (this.currentSpriterTime - playTo) < 0 || this.currentSpriterTime === playTo)
+                        {
+                                this.currentSpriterTime = playTo;
+                                this.animPlaying = false;
+                                this.playTo = -1;
+                                animationFinished = true;
+                        }
+                }
+
+                if (!animationFinished)
+                {
+                        if (this.speedRatio >= 0)
+                        {
+                                if (this.currentSpriterTime >= length)
+                                {
+                                        if (this._isAnimationLooping(animation))
+                                        {
+                                                this.currentSpriterTime = this.currentSpriterTime % length;
+                                        }
+                                        else
+                                        {
+                                                this.currentSpriterTime = length;
+                                                this.animPlaying = false;
+                                                animationFinished = true;
+                                        }
+                                }
+                        }
+                        else if (this.currentSpriterTime <= 0)
+                        {
+                                if (this._isAnimationLooping(animation))
+                                {
+                                        const wrappedTime = ((this.currentSpriterTime % length) + length) % length;
+                                        this.currentSpriterTime = wrappedTime;
+                                }
+                                else
+                                {
+                                        this.currentSpriterTime = 0;
+                                        this.animPlaying = false;
+                                        animationFinished = true;
+                                }
+                        }
+                }
+
+                this.currentAdjustedTime = Math.max(0, Math.min(length, this.currentSpriterTime));
+
+                if (animationFinished)
+                {
+                        this._onAnimationFinished(animation);
+                }
         }
 
         _saveToJson()


### PR DESCRIPTION
## Summary
- normalise loaded Spriter entities and wire up entity/animation selection with timekeeping in the SDK v2 runtime
- implement the `_tick` update loop so playback advances according to Construct's time scale and speed controls
- expose a `Set Animation` action and record progress in the ticking/playback phase checklist

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d4e32b308322bc8dfb7032051fe0)