### PR TITLE
Implement Spriter keyframe interpolation in SDK v2 runtime

### DIFF
--- a/docs/phases/phase-03-ticking-and-playback.md
+++ b/docs/phases/phase-03-ticking-and-playback.md
@@ -5,7 +5,7 @@ Ensure the SDK v2 runtime can advance Spriter animations each tick and expose mi
 
 ## Checklist
 - [x] Port timekeeping helpers (e.g., `getNowTime`) and ensure they respect Construct's timescale options when advancing animations.
-- [ ] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`. _(Entity selection and animation timing added; keyframe interpolation remains to be ported.)_
+- [x] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`.
 - [x] Expose at least one action (e.g., `Set Animation`) through `C3.Plugins.Spriter.Acts` to drive playback from Construct events.
 
 ## Using this file

--- a/scml2/c3runtime/instance.js
+++ b/scml2/c3runtime/instance.js
@@ -141,6 +141,12 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this._eventListenerDisposables = new Set();
                 this._isReleased = false;
                 this._hasShownBlendWarning = false;
+
+                this._currentMainlineKeyIndex = -1;
+                this._currentMainlineKey = null;
+                this._currentBoneStates = [];
+                this._currentObjectStates = [];
+                this._timelineStateCache = new Map();
         }
 
         _release()
@@ -651,6 +657,39 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this._eventListenerDisposables.clear();
         }
 
+        _resetTimelineState()
+        {
+                this._currentMainlineKeyIndex = -1;
+                this._currentMainlineKey = null;
+
+                if (Array.isArray(this._currentBoneStates))
+                {
+                        this._currentBoneStates.length = 0;
+                }
+                else
+                {
+                        this._currentBoneStates = [];
+                }
+
+                if (Array.isArray(this._currentObjectStates))
+                {
+                        this._currentObjectStates.length = 0;
+                }
+                else
+                {
+                        this._currentObjectStates = [];
+                }
+
+                if (this._timelineStateCache && typeof this._timelineStateCache.clear === "function")
+                {
+                        this._timelineStateCache.clear();
+                }
+                else
+                {
+                        this._timelineStateCache = new Map();
+                }
+        }
+
         _clearAnimationStateCaches()
         {
                 if (Array.isArray(this.nodeStack))
@@ -684,6 +723,8 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this.soundLineToTrigger = {};
                 this.eventLineToTrigger = {};
                 this.lastFoundObject = "";
+
+                this._resetTimelineState();
 
                 this.currentAnimation = null;
                 this.currentAnimationIndex = -1;
@@ -731,30 +772,343 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 const normalised = { ...entityDefinition };
                 const animations = [];
 
+                const sourceAnimations = [];
+
                 if (Array.isArray(entityDefinition.animations))
                 {
-                        for (const animation of entityDefinition.animations)
-                        {
-                                if (animation && typeof animation === "object")
-                                {
-                                        animations.push(animation);
-                                }
-                        }
+                        sourceAnimations.push(...entityDefinition.animations);
                 }
                 else if (Array.isArray(entityDefinition.animation))
                 {
-                        for (const animation of entityDefinition.animation)
+                        sourceAnimations.push(...entityDefinition.animation);
+                }
+
+                for (const animation of sourceAnimations)
+                {
+                        const normalisedAnimation = this._normaliseAnimationDefinition(animation);
+                        if (normalisedAnimation)
                         {
-                                if (animation && typeof animation === "object")
-                                {
-                                        animations.push(animation);
-                                }
+                                animations.push(normalisedAnimation);
                         }
                 }
 
                 normalised.animation = animations;
                 normalised.animations = animations;
                 return normalised;
+        }
+
+        _normaliseAnimationDefinition(animationDefinition)
+        {
+                if (!animationDefinition || typeof animationDefinition !== "object")
+                {
+                        return null;
+                }
+
+                const normalised = { ...animationDefinition };
+                normalised.length = this._coerceNumber(animationDefinition.length, 0);
+                normalised.looping = animationDefinition.looping;
+
+                const mainlineKeys = this._normaliseMainlineKeys(animationDefinition);
+                normalised.mainlineKeys = mainlineKeys;
+
+                const timelines = this._normaliseTimelineDefinitions(animationDefinition.timeline || animationDefinition.timelines);
+                normalised.timelines = timelines;
+
+                const timelineMap = new Map();
+                for (const timeline of timelines)
+                {
+                        if (!timeline)
+                        {
+                                continue;
+                        }
+
+                        const timelineId = Number.isInteger(timeline.id) ? timeline.id : timeline.index;
+                        timelineMap.set(timelineId, timeline);
+                }
+
+                normalised._timelinesById = timelineMap;
+
+                if (!Array.isArray(normalised.soundlines) && Array.isArray(animationDefinition.soundlines))
+                {
+                        normalised.soundlines = animationDefinition.soundlines;
+                }
+
+                if (!Array.isArray(normalised.meta) && animationDefinition.meta)
+                {
+                        normalised.meta = animationDefinition.meta;
+                }
+
+                return normalised;
+        }
+
+        _normaliseMainlineKeys(animationDefinition)
+        {
+                const keys = [];
+                if (!animationDefinition)
+                {
+                        return keys;
+                }
+
+                let keySources = [];
+
+                if (Array.isArray(animationDefinition.mainlineKeys))
+                {
+                        keySources = animationDefinition.mainlineKeys;
+                }
+                else if (animationDefinition.mainline && typeof animationDefinition.mainline === "object")
+                {
+                        const mainline = animationDefinition.mainline;
+                        if (Array.isArray(mainline.keys))
+                        {
+                                keySources = mainline.keys;
+                        }
+                        else if (Array.isArray(mainline.key))
+                        {
+                                keySources = mainline.key;
+                        }
+                }
+
+                let fallbackId = 0;
+                for (const keyDefinition of keySources)
+                {
+                        const normalisedKey = this._normaliseMainlineKey(keyDefinition, fallbackId);
+                        if (normalisedKey)
+                        {
+                                fallbackId = normalisedKey.nextFallbackId;
+                                keys.push(normalisedKey.key);
+                        }
+                }
+
+                return keys;
+        }
+
+        _normaliseMainlineKey(keyDefinition, fallbackId)
+        {
+                if (!keyDefinition || typeof keyDefinition !== "object")
+                {
+                        return null;
+                }
+
+                const time = this._coerceNumber(keyDefinition.time, 0);
+                const curveTypeSource = keyDefinition.curveType || keyDefinition.curve_type || "linear";
+                const curveType = typeof curveTypeSource === "string" ? curveTypeSource : "linear";
+
+                const bones = [];
+                const objects = [];
+
+                const boneRefs = Array.isArray(keyDefinition.bones)
+                        ? keyDefinition.bones
+                        : Array.isArray(keyDefinition.bone_ref)
+                                ? keyDefinition.bone_ref
+                                : [];
+
+                const objectRefs = Array.isArray(keyDefinition.objects)
+                        ? keyDefinition.objects
+                        : Array.isArray(keyDefinition.object_ref)
+                                ? keyDefinition.object_ref
+                                : [];
+
+                let nextFallbackId = fallbackId;
+
+                for (const ref of boneRefs)
+                {
+                        const { ref: normalisedRef, nextId } = this._normaliseMainlineRef(ref, nextFallbackId);
+                        if (normalisedRef)
+                        {
+                                nextFallbackId = nextId;
+                                bones.push(normalisedRef);
+                        }
+                }
+
+                for (const ref of objectRefs)
+                {
+                        const { ref: normalisedRef, nextId } = this._normaliseMainlineRef(ref, nextFallbackId);
+                        if (normalisedRef)
+                        {
+                                nextFallbackId = nextId;
+                                objects.push(normalisedRef);
+                        }
+                }
+
+                return {
+                        key: {
+                                time,
+                                curveType,
+                                c1: this._coerceNumber(keyDefinition.c1, 0),
+                                c2: this._coerceNumber(keyDefinition.c2, 0),
+                                c3: this._coerceNumber(keyDefinition.c3, 0),
+                                c4: this._coerceNumber(keyDefinition.c4, 0),
+                                bones,
+                                objects
+                        },
+                        nextFallbackId
+                };
+        }
+
+        _normaliseMainlineRef(refDefinition, fallbackId)
+        {
+                if (!refDefinition || typeof refDefinition !== "object")
+                {
+                        return { ref: null, nextId: fallbackId };
+                }
+
+                const refIdRaw = ("id" in refDefinition) ? Number(refDefinition.id) : NaN;
+                const refId = Number.isInteger(refIdRaw) && refIdRaw >= 0 ? refIdRaw : fallbackId;
+                const parentRaw = ("parent" in refDefinition) ? Number(refDefinition.parent) : NaN;
+                const parent = Number.isInteger(parentRaw) ? parentRaw : -1;
+                const timeline = this._coerceNumber(refDefinition.timeline, -1);
+                const key = this._coerceNumber(refDefinition.key, 0);
+
+                const normalised = {
+                        id: refId,
+                        parent,
+                        timeline,
+                        key,
+                        name: typeof refDefinition.name === "string" ? refDefinition.name : ""
+                };
+
+                const nextId = refId + 1;
+                return { ref: normalised, nextId };
+        }
+
+        _normaliseTimelineDefinitions(timelineDefinitions)
+        {
+                if (!Array.isArray(timelineDefinitions))
+                {
+                        return [];
+                }
+
+                const timelines = [];
+                for (let i = 0; i < timelineDefinitions.length; i++)
+                {
+                        const normalised = this._normaliseTimelineDefinition(timelineDefinitions[i], i);
+                        if (normalised)
+                        {
+                                timelines.push(normalised);
+                        }
+                }
+
+                return timelines;
+        }
+
+        _normaliseTimelineDefinition(timelineDefinition, index)
+        {
+                if (!timelineDefinition || typeof timelineDefinition !== "object")
+                {
+                        return null;
+                }
+
+                const objectTypeSource = timelineDefinition.objectType || timelineDefinition.object_type || "sprite";
+                const objectType = typeof objectTypeSource === "string" ? objectTypeSource : "sprite";
+                const timelineIdRaw = ("id" in timelineDefinition) ? Number(timelineDefinition.id) : NaN;
+                const timelineId = Number.isInteger(timelineIdRaw) ? timelineIdRaw : index;
+
+                const keysSource = Array.isArray(timelineDefinition.keys)
+                        ? timelineDefinition.keys
+                        : Array.isArray(timelineDefinition.key)
+                                ? timelineDefinition.key
+                                : [];
+
+                const keys = [];
+                for (let keyIndex = 0; keyIndex < keysSource.length; keyIndex++)
+                {
+                        const keyDefinition = keysSource[keyIndex];
+                        const normalisedKey = this._normaliseTimelineKey(keyDefinition, objectType, keyIndex);
+                        if (normalisedKey)
+                        {
+                                keys.push(normalisedKey);
+                        }
+                }
+
+                return {
+                        id: timelineId,
+                        index: index,
+                        name: typeof timelineDefinition.name === "string" ? timelineDefinition.name : "",
+                        objectType,
+                        keys,
+                        meta: timelineDefinition.meta || null
+                };
+        }
+
+        _normaliseTimelineKey(keyDefinition, objectType, keyIndex)
+        {
+                if (!keyDefinition || typeof keyDefinition !== "object")
+                {
+                        return null;
+                }
+
+                const time = this._coerceNumber(keyDefinition.time, 0);
+                const spinRaw = ("spin" in keyDefinition) ? Number(keyDefinition.spin) : NaN;
+                const spin = Number.isFinite(spinRaw) ? spinRaw : 1;
+                const curveTypeSource = keyDefinition.curveType || keyDefinition.curve_type || "linear";
+                const curveType = typeof curveTypeSource === "string" ? curveTypeSource : "linear";
+
+                const key = {
+                        index: keyIndex,
+                        time,
+                        spin,
+                        curveType,
+                        c1: this._coerceNumber(keyDefinition.c1, 0),
+                        c2: this._coerceNumber(keyDefinition.c2, 0),
+                        c3: this._coerceNumber(keyDefinition.c3, 0),
+                        c4: this._coerceNumber(keyDefinition.c4, 0),
+                        objectType
+                };
+
+                const objectCandidate = keyDefinition.object || (Array.isArray(keyDefinition.objects) ? keyDefinition.objects[0] : null);
+                const boneCandidate = keyDefinition.bone || (Array.isArray(keyDefinition.bones) ? keyDefinition.bones[0] : null);
+
+                if (objectType === "bone" || boneCandidate)
+                {
+                        key.objectType = "bone";
+                        key.bone = this._normaliseTimelineBone(boneCandidate || objectCandidate);
+                }
+                else
+                {
+                        key.objectType = objectType;
+                        key.object = this._normaliseTimelineObject(objectCandidate);
+                }
+
+                return key;
+        }
+
+        _normaliseTimelineObject(objectDefinition)
+        {
+                if (!objectDefinition || typeof objectDefinition !== "object")
+                {
+                        return null;
+                }
+
+                return {
+                        x: this._coerceNumber(objectDefinition.x, 0),
+                        y: this._coerceNumber(objectDefinition.y, 0),
+                        angle: this._coerceNumber(objectDefinition.angle, 0),
+                        scaleX: this._coerceNumber(objectDefinition.scaleX ?? objectDefinition.scale_x, 1),
+                        scaleY: this._coerceNumber(objectDefinition.scaleY ?? objectDefinition.scale_y, 1),
+                        pivotX: this._coerceNumber(objectDefinition.pivotX ?? objectDefinition.pivot_x, this._coerceNumber(objectDefinition.defaultPivotX, 0)),
+                        pivotY: this._coerceNumber(objectDefinition.pivotY ?? objectDefinition.pivot_y, this._coerceNumber(objectDefinition.defaultPivotY, 0)),
+                        alpha: this._coerceNumber(objectDefinition.a ?? objectDefinition.alpha, 1),
+                        folder: this._coerceNumber(objectDefinition.folder, -1),
+                        file: this._coerceNumber(objectDefinition.file, -1),
+                        entity: this._coerceNumber(objectDefinition.entity, -1),
+                        animation: this._coerceNumber(objectDefinition.animation, -1)
+                };
+        }
+
+        _normaliseTimelineBone(boneDefinition)
+        {
+                if (!boneDefinition || typeof boneDefinition !== "object")
+                {
+                        return null;
+                }
+
+                return {
+                        x: this._coerceNumber(boneDefinition.x, 0),
+                        y: this._coerceNumber(boneDefinition.y, 0),
+                        angle: this._coerceNumber(boneDefinition.angle, 0),
+                        scaleX: this._coerceNumber(boneDefinition.scaleX ?? boneDefinition.scale_x, 1),
+                        scaleY: this._coerceNumber(boneDefinition.scaleY ?? boneDefinition.scale_y, 1)
+                };
         }
 
         _applyPendingPlaybackPreferences()
@@ -959,6 +1313,7 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                         this.currentAnimationName = "";
                         this.currentSpriterTime = 0;
                         this.currentAdjustedTime = 0;
+                        this._resetTimelineState();
                         return false;
                 }
 
@@ -984,6 +1339,7 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this.currentAnimationName = "";
                 this.currentSpriterTime = 0;
                 this.currentAdjustedTime = 0;
+                this._resetTimelineState();
 
                 if (entity && typeof entity.name === "string" && entity.name)
                 {
@@ -1152,7 +1508,9 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 this.animPlaying = true;
                 this.force = true;
 
+                this._resetTimelineState();
                 this._updateWorldBoundsFromAnimation(animation);
+                this._updateAnimationState();
                 return true;
         }
 
@@ -1274,6 +1632,616 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 return Math.max(0, Math.min(1, this.currentSpriterTime / length));
         }
 
+        _updateAnimationState()
+        {
+                const animation = this.currentAnimation;
+                if (!animation)
+                {
+                        this._resetTimelineState();
+                        return;
+                }
+
+                const mainlineKeys = Array.isArray(animation.mainlineKeys) ? animation.mainlineKeys : [];
+                if (!mainlineKeys.length)
+                {
+                        this._resetTimelineState();
+                        return;
+                }
+
+                const length = this._getAnimationLength(animation);
+                const isLooping = this._isAnimationLooping(animation);
+                const time = this._clamp(this.currentAdjustedTime, 0, length || 0);
+
+                const mainlineInterval = this._findKeyInterval(mainlineKeys, time, length, isLooping);
+                if (!mainlineInterval)
+                {
+                        this._resetTimelineState();
+                        return;
+                }
+
+                const { keyIndex, key } = mainlineInterval;
+                this._currentMainlineKeyIndex = keyIndex;
+                this._currentMainlineKey = key;
+
+                const rootTransform = this._getRootTransform();
+                const stateByRefId = new Map();
+                const boneStates = [];
+                const objectStates = [];
+
+                if (Array.isArray(key.bones))
+                {
+                        for (const boneRef of key.bones)
+                        {
+                                const state = this._computeTimelineState(animation, boneRef, time, length, isLooping, stateByRefId, rootTransform, true);
+                                if (state)
+                                {
+                                        boneStates.push(state);
+                                        if (Number.isInteger(boneRef && boneRef.id))
+                                        {
+                                                stateByRefId.set(boneRef.id, state);
+                                        }
+                                }
+                        }
+                }
+
+                if (Array.isArray(key.objects))
+                {
+                        for (const objectRef of key.objects)
+                        {
+                                const state = this._computeTimelineState(animation, objectRef, time, length, isLooping, stateByRefId, rootTransform, false);
+                                if (state)
+                                {
+                                        objectStates.push(state);
+                                        if (Number.isInteger(objectRef && objectRef.id))
+                                        {
+                                                stateByRefId.set(objectRef.id, state);
+                                        }
+                                }
+                        }
+                }
+
+                this._currentBoneStates = boneStates;
+                this._currentObjectStates = objectStates;
+
+                if (this._timelineStateCache && typeof this._timelineStateCache.clear === "function")
+                {
+                        this._timelineStateCache.clear();
+
+                        for (const state of boneStates)
+                        {
+                                if (Number.isInteger(state.timelineId))
+                                {
+                                        this._timelineStateCache.set(state.timelineId, state);
+                                }
+                        }
+
+                        for (const state of objectStates)
+                        {
+                                if (Number.isInteger(state.timelineId))
+                                {
+                                        this._timelineStateCache.set(state.timelineId, state);
+                                }
+                        }
+                }
+        }
+
+        _computeTimelineState(animation, ref, time, length, isLooping, stateByRefId, rootTransform, isBone)
+        {
+                if (!ref || typeof ref !== "object")
+                {
+                        return null;
+                }
+
+                const timeline = this._getTimelineFromRef(animation, ref);
+                if (!timeline)
+                {
+                        return null;
+                }
+
+                const localState = this._sampleTimelineLocalState(animation, timeline, time, length, isLooping, ref.key);
+                if (!localState)
+                {
+                        return null;
+                }
+
+                const parentId = Number.isInteger(ref.parent) ? ref.parent : -1;
+                const parentState = parentId >= 0 ? stateByRefId.get(parentId) : null;
+                const parentWorld = parentState ? parentState.world : rootTransform;
+                const world = this._composeWorldState(localState, parentWorld);
+
+                return {
+                        id: Number.isInteger(ref.id) ? ref.id : -1,
+                        parentId,
+                        timelineId: Number.isInteger(timeline.id) ? timeline.id : timeline.index,
+                        timelineName: typeof timeline.name === "string" ? timeline.name : "",
+                        objectType: isBone ? "bone" : (timeline.objectType || "sprite"),
+                        local: localState,
+                        world,
+                        folder: localState.folder ?? -1,
+                        file: localState.file ?? -1,
+                        entity: localState.entity ?? -1,
+                        animation: localState.animation ?? -1,
+                        pivotX: localState.pivotX ?? 0,
+                        pivotY: localState.pivotY ?? 0,
+                        alpha: world.alpha ?? 1
+                };
+        }
+
+        _sampleTimelineLocalState(animation, timeline, time, length, isLooping, keyIndexHint)
+        {
+                const keys = Array.isArray(timeline.keys) ? timeline.keys : [];
+                if (!keys.length)
+                {
+                        return null;
+                }
+
+                const interval = this._findKeyInterval(keys, time, length, isLooping, keyIndexHint);
+                if (!interval)
+                {
+                        return this._cloneTimelineValue(keys[0]);
+                }
+
+                const { key, nextKey, keyIndex, nextIndex, t } = interval;
+
+                const fromState = this._cloneTimelineValue(key);
+                if (!fromState)
+                {
+                        return null;
+                }
+
+                if (!nextKey || keyIndex === nextIndex || key === nextKey)
+                {
+                        return fromState;
+                }
+
+                const toState = this._cloneTimelineValue(nextKey);
+                if (!toState)
+                {
+                        return fromState;
+                }
+
+                const spin = Number.isFinite(key.spin) ? key.spin : 1;
+                const curveT = this._applyCurveToT(key, this._clamp(t, 0, 1));
+                return this._interpolateObjectState(fromState, toState, curveT, spin, key.objectType === "bone");
+        }
+
+        _cloneTimelineValue(key)
+        {
+                if (!key)
+                {
+                        return null;
+                }
+
+                if (key.objectType === "bone")
+                {
+                        return key.bone ? { ...key.bone } : null;
+                }
+
+                return key.object ? { ...key.object } : null;
+        }
+
+        _interpolateObjectState(a, b, t, spin, isBone)
+        {
+                const from = a ? { ...a } : null;
+                const to = b ? { ...b } : null;
+
+                if (!from && !to)
+                {
+                        return null;
+                }
+
+                if (!from)
+                {
+                        return to;
+                }
+
+                if (!to)
+                {
+                        return from;
+                }
+
+                const result = { ...from };
+
+                result.x = this._lerp(from.x ?? 0, to.x ?? 0, t);
+                result.y = this._lerp(from.y ?? 0, to.y ?? 0, t);
+                result.angle = this._angleLerpDegrees(from.angle ?? 0, to.angle ?? 0, t, spin);
+                result.scaleX = this._lerp(from.scaleX ?? 1, to.scaleX ?? 1, t);
+                result.scaleY = this._lerp(from.scaleY ?? 1, to.scaleY ?? 1, t);
+
+                if (!isBone)
+                {
+                        result.pivotX = this._lerp(from.pivotX ?? 0, to.pivotX ?? 0, t);
+                        result.pivotY = this._lerp(from.pivotY ?? 0, to.pivotY ?? 0, t);
+                        result.alpha = this._lerp(from.alpha ?? 1, to.alpha ?? 1, t);
+
+                        const chooseNext = t >= 0.999;
+                        result.folder = chooseNext ? (to.folder ?? from.folder ?? -1) : (from.folder ?? to.folder ?? -1);
+                        result.file = chooseNext ? (to.file ?? from.file ?? -1) : (from.file ?? to.file ?? -1);
+                        result.entity = chooseNext ? (to.entity ?? from.entity ?? -1) : (from.entity ?? to.entity ?? -1);
+                        result.animation = chooseNext ? (to.animation ?? from.animation ?? -1) : (from.animation ?? to.animation ?? -1);
+                }
+
+                return result;
+        }
+
+        _composeWorldState(local, parent)
+        {
+                const parentX = this._coerceNumber(parent && parent.x, 0);
+                const parentY = this._coerceNumber(parent && parent.y, 0);
+                const parentAngle = this._coerceNumber(parent && parent.angle, 0);
+                const parentScaleX = this._coerceNumber(parent && parent.scaleX, 1);
+                const parentScaleY = this._coerceNumber(parent && parent.scaleY, 1);
+                const parentAlpha = this._coerceNumber(parent && parent.alpha, 1);
+
+                const angleRad = this._degreesToRadians(parentAngle);
+                const cos = Math.cos(angleRad);
+                const sin = Math.sin(angleRad);
+
+                const localX = this._coerceNumber(local.x, 0) * parentScaleX;
+                const localY = this._coerceNumber(local.y, 0) * parentScaleY;
+
+                const rotatedX = localX * cos - localY * sin;
+                const rotatedY = localX * sin + localY * cos;
+
+                const worldAngle = this._normaliseAngleDegrees(parentAngle + this._coerceNumber(local.angle, 0));
+
+                return {
+                        x: parentX + rotatedX,
+                        y: parentY + rotatedY,
+                        angle: worldAngle,
+                        scaleX: parentScaleX * this._coerceNumber(local.scaleX, 1),
+                        scaleY: parentScaleY * this._coerceNumber(local.scaleY, 1),
+                        alpha: parentAlpha * (local.alpha != null ? local.alpha : 1)
+                };
+        }
+
+        _getRootTransform()
+        {
+                const baseScaleX = this._coerceNumber(this.scaleRatio, 1) * this._coerceNumber(this.subEntScaleX, 1);
+                const baseScaleY = this._coerceNumber(this.scaleRatio, 1) * this._coerceNumber(this.subEntScaleY, 1);
+                const flipX = this.xFlip ? -1 : 1;
+                const flipY = this.yFlip ? -1 : 1;
+
+                return {
+                        x: 0,
+                        y: 0,
+                        angle: 0,
+                        scaleX: baseScaleX * flipX,
+                        scaleY: baseScaleY * flipY,
+                        alpha: 1
+                };
+        }
+
+        _findKeyInterval(keys, time, length, isLooping, keyIndexHint)
+        {
+                if (!Array.isArray(keys) || !keys.length)
+                {
+                        return null;
+                }
+
+                const animationLength = Number.isFinite(length) ? Math.max(length, 0) : 0;
+                const currentTime = Number.isFinite(time) ? time : 0;
+
+                let startIndex = -1;
+
+                if (Number.isInteger(keyIndexHint) && keyIndexHint >= 0 && keyIndexHint < keys.length)
+                {
+                        startIndex = keyIndexHint;
+                }
+
+                if (startIndex === -1)
+                {
+                        for (let i = keys.length - 1; i >= 0; i--)
+                        {
+                                const candidate = keys[i];
+                                if (!candidate)
+                                {
+                                        continue;
+                                }
+
+                                const candidateTime = this._coerceNumber(candidate.time, 0);
+                                if (currentTime >= candidateTime)
+                                {
+                                        startIndex = i;
+                                        break;
+                                }
+                        }
+
+                        if (startIndex === -1)
+                        {
+                                startIndex = 0;
+                        }
+                }
+
+                const key = keys[startIndex];
+                if (!key)
+                {
+                        return null;
+                }
+
+                let nextIndex = startIndex + 1;
+                if (nextIndex >= keys.length)
+                {
+                        nextIndex = isLooping ? 0 : startIndex;
+                }
+
+                const nextKey = keys[nextIndex] || key;
+                const keyTime = this._coerceNumber(key.time, 0);
+                let nextTime = this._coerceNumber(nextKey.time, keyTime);
+                let wrapped = false;
+
+                if (nextIndex <= startIndex)
+                {
+                        nextTime += animationLength;
+                        wrapped = true;
+                }
+
+                let adjustedTime = currentTime;
+                if (isLooping && adjustedTime < keyTime)
+                {
+                        adjustedTime += animationLength;
+                }
+
+                const duration = nextTime - keyTime;
+                const rawT = duration > 0 ? this._clamp((adjustedTime - keyTime) / duration, 0, 1) : 0;
+
+                return {
+                        keyIndex: startIndex,
+                        key,
+                        nextIndex,
+                        nextKey,
+                        keyTime,
+                        nextTime,
+                        t: rawT,
+                        wrapped
+                };
+        }
+
+        _applyCurveToT(key, t)
+        {
+                if (!key)
+                {
+                        return t;
+                }
+
+                const curveType = typeof key.curveType === "string" ? key.curveType.toLowerCase() : "linear";
+
+                switch (curveType)
+                {
+                        case "linear":
+                                return t;
+                        case "quadratic":
+                                return this._qerp(0, this._coerceNumber(key.c1, 0), 1, t);
+                        case "cubic":
+                                return this._cerp(0, this._coerceNumber(key.c1, 0), this._coerceNumber(key.c2, 0), 1, t);
+                        case "quartic":
+                                return this._quartic(0, this._coerceNumber(key.c1, 0), this._coerceNumber(key.c2, 0), this._coerceNumber(key.c3, 0), 1, t);
+                        case "quintic":
+                                return this._quintic(0, this._coerceNumber(key.c1, 0), this._coerceNumber(key.c2, 0), this._coerceNumber(key.c3, 0), this._coerceNumber(key.c4, 0), 1, t);
+                        case "bezier":
+                                return this._cubicBezierAtTime(t, this._coerceNumber(key.c1, 0), this._coerceNumber(key.c2, 0), this._coerceNumber(key.c3, 1), this._coerceNumber(key.c4, 1));
+                        case "instant":
+                                return t >= 1 ? 1 : 0;
+                        default:
+                                return t;
+                }
+        }
+
+        _getTimelineFromRef(animation, ref)
+        {
+                if (!animation || !ref)
+                {
+                        return null;
+                }
+
+                const timelines = Array.isArray(animation.timelines) ? animation.timelines : [];
+
+                if (Number.isInteger(ref.timeline))
+                {
+                        const map = animation._timelinesById;
+                        if (map && typeof map.get === "function" && map.has(ref.timeline))
+                        {
+                                return map.get(ref.timeline);
+                        }
+
+                        if (ref.timeline >= 0 && ref.timeline < timelines.length)
+                        {
+                                return timelines[ref.timeline];
+                        }
+                }
+
+                if (typeof ref.timeline === "string")
+                {
+                        const lower = ref.timeline.toLowerCase();
+                        for (const timeline of timelines)
+                        {
+                                if (timeline && typeof timeline.name === "string" && timeline.name.toLowerCase() === lower)
+                                {
+                                        return timeline;
+                                }
+                        }
+                }
+
+                return null;
+        }
+
+        _lerp(a, b, t)
+        {
+                return ((b - a) * t) + a;
+        }
+
+        _qerp(a, b, c, t)
+        {
+                return this._lerp(this._lerp(a, b, t), this._lerp(b, c, t), t);
+        }
+
+        _cerp(a, b, c, d, t)
+        {
+                return this._lerp(this._qerp(a, b, c, t), this._qerp(b, c, d, t), t);
+        }
+
+        _quartic(a, b, c, d, e, t)
+        {
+                return this._lerp(this._cerp(a, b, c, d, t), this._cerp(b, c, d, e, t), t);
+        }
+
+        _quintic(a, b, c, d, e, f, t)
+        {
+                return this._lerp(this._quartic(a, b, c, d, e, t), this._quartic(b, c, d, e, f, t), t);
+        }
+
+        _cubicBezierAtTime(t, p1x, p1y, p2x, p2y)
+        {
+                const cx = 3.0 * p1x;
+                const bx = 3.0 * (p2x - p1x) - cx;
+                const ax = 1.0 - cx - bx;
+                const cy = 3.0 * p1y;
+                const by = 3.0 * (p2y - p1y) - cy;
+                const ay = 1.0 - cy - by;
+                return this._solve(ax, bx, cx, ay, by, cy, t, this._solveEpsilon(1.0));
+        }
+
+        _sampleCurve(a, b, c, t)
+        {
+                return ((a * t + b) * t + c) * t;
+        }
+
+        _sampleCurveDerivativeX(ax, bx, cx, t)
+        {
+                return (3.0 * ax * t + 2.0 * bx) * t + cx;
+        }
+
+        _solveCurveX(ax, bx, cx, x, epsilon)
+        {
+                let t2 = x;
+                let x2;
+                let d2;
+
+                for (let i = 0; i < 8; i++)
+                {
+                        x2 = this._sampleCurve(ax, bx, cx, t2) - x;
+                        if (Math.abs(x2) < epsilon)
+                        {
+                                return t2;
+                        }
+                        d2 = this._sampleCurveDerivativeX(ax, bx, cx, t2);
+                        if (Math.abs(d2) < 1e-6)
+                        {
+                                break;
+                        }
+                        t2 -= x2 / d2;
+                }
+
+                let t0 = 0;
+                let t1 = 1;
+                t2 = x;
+
+                while (t0 < t1)
+                {
+                        x2 = this._sampleCurve(ax, bx, cx, t2);
+                        if (Math.abs(x2 - x) < epsilon)
+                        {
+                                return t2;
+                        }
+                        if (x > x2)
+                        {
+                                t0 = t2;
+                        }
+                        else
+                        {
+                                t1 = t2;
+                        }
+                        t2 = (t1 - t0) * 0.5 + t0;
+                }
+
+                return t2;
+        }
+
+        _solveEpsilon(duration)
+        {
+                return 1.0 / (200.0 * duration);
+        }
+
+        _solve(ax, bx, cx, ay, by, cy, x, epsilon)
+        {
+                return this._sampleCurve(ay, by, cy, this._solveCurveX(ax, bx, cx, x, epsilon));
+        }
+
+        _degreesToRadians(angle)
+        {
+                return angle * (Math.PI / 180);
+        }
+
+        _radiansToDegrees(radians)
+        {
+                return radians * (180 / Math.PI);
+        }
+
+        _angleDiffRadians(a, b)
+        {
+                let diff = b - a;
+
+                while (diff < -Math.PI)
+                {
+                        diff += Math.PI * 2;
+                }
+
+                while (diff > Math.PI)
+                {
+                        diff -= Math.PI * 2;
+                }
+
+                return diff;
+        }
+
+        _angleLerpDegrees(a, b, t, spin)
+        {
+                const start = Number.isFinite(a) ? a : 0;
+                const end = Number.isFinite(b) ? b : 0;
+
+                if (spin === 0)
+                {
+                        return this._normaliseAngleDegrees(start);
+                }
+
+                const startRad = this._degreesToRadians(start);
+                const endRad = this._degreesToRadians(end);
+                const diff = this._angleDiffRadians(startRad, endRad);
+                const delta = spin === -1 ? diff : -diff;
+                const resultRad = startRad + delta * t;
+                return this._normaliseAngleDegrees(this._radiansToDegrees(resultRad));
+        }
+
+        _normaliseAngleDegrees(angle)
+        {
+                if (!Number.isFinite(angle))
+                {
+                        return 0;
+                }
+
+                let normalised = angle % 360;
+                if (normalised > 180)
+                {
+                        normalised -= 360;
+                }
+                else if (normalised < -180)
+                {
+                        normalised += 360;
+                }
+
+                return normalised;
+        }
+
+        _clamp(value, min, max)
+        {
+                if (!Number.isFinite(value))
+                {
+                        return min;
+                }
+
+                return Math.min(max, Math.max(min, value));
+        }
+
         _onDestroy()
         {
                 if (this.isDestroyed)
@@ -1312,6 +2280,7 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 const animation = this.currentAnimation;
                 if (!animation)
                 {
+                        this._resetTimelineState();
                         return;
                 }
 
@@ -1396,6 +2365,8 @@ C3.Plugins.Spriter.Instance = class SpriterInstance extends globalThis.ISDKWorld
                 {
                         this._onAnimationFinished(animation);
                 }
+
+                this._updateAnimationState();
         }
 
         _saveToJson()


### PR DESCRIPTION
## Summary
- normalise Spriter animation data and cache timelines for the SDK v2 runtime
- compute curve-aware bone and object world states every tick to drive playback
- update the ticking and playback phase checklist to reflect the interpolation work

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153cdcaf3483228633fafe9e61a1af)