### PR TITLE
Implement keyframe interpolation in Spriter runtime

### DIFF
--- a/docs/phases/phase-03-ticking-and-playback.md
+++ b/docs/phases/phase-03-ticking-and-playback.md
@@ -5,7 +5,7 @@ Ensure the SDK v2 runtime can advance Spriter animations each tick and expose mi
 
 ## Checklist
 - [x] Port timekeeping helpers (e.g., `getNowTime`) and ensure they respect Construct's timescale options when advancing animations.
-- [ ] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`. _(Entity selection and animation timing added; keyframe interpolation remains to be ported.)_
+- [x] Implement entity/animation selection logic and keyframe interpolation so playback state updates every `_tick`. _(Mainline curves and timeline interpolation now update state caches each frame.)_
 - [x] Expose at least one action (e.g., `Set Animation`) through `C3.Plugins.Spriter.Acts` to drive playback from Construct events.
 
 ## Using this file


### PR DESCRIPTION
## Summary
- add per-animation caching helpers to derive current mainline keys and interpolate timeline states every tick
- update setAnimation/tick to reuse the resolved mainline state and maintain a reusable frame-state cache
- mark the phase 3 checklist item for keyframe interpolation as complete now that runtime state updates are in place

## Testing
- node --check scml2/c3runtime/instance.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e1193ee48322a83d2b22b1dbfcd9)